### PR TITLE
Feature/unify to dataframe

### DIFF
--- a/src/fukinotou/dataframe_exportable.py
+++ b/src/fukinotou/dataframe_exportable.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from typing import List, Any
+
+
+import polars
+import pandas
+
+
+class DataframeExportable:
+    path: Path
+    value: List[Any]
+
+    def to_polars(self, include_path_as_column: bool = False) -> polars.DataFrame:
+        """Convert the result to a Polars DataFrame.
+
+        This method converts all model instances in the result to a Polars DataFrame.
+        Each row in the DataFrame represents one model instance.
+
+        Args:
+            include_path_as_column: If True, adds a 'path' column with the file path
+                                    for each row. Default is False.
+
+        Returns:
+            Polars DataFrame containing the model data
+        """
+        if not self.value:
+            return polars.DataFrame()
+
+        data_dicts = [row.value.model_dump() for row in self.value]
+        df = polars.DataFrame(data_dicts)
+
+        if include_path_as_column:
+            df = df.with_columns(polars.lit(str(self.path)).alias("path"))
+
+        return df
+
+    def to_pandas(self, include_path_as_column: bool = False) -> pandas.DataFrame:
+        """Convert the result to a Pandas DataFrame.
+
+        This method converts all model instances in the result to a Pandas DataFrame.
+        Each row in the DataFrame represents one model instance.
+
+        Args:
+            include_path_as_column: If True, adds a 'path' column with the file path
+                                    for each row. Default is False.
+
+        Returns:
+            Pandas DataFrame containing the model data
+        """
+        if not self.value:
+            return pandas.DataFrame()
+
+        data_dicts = [row.value.model_dump() for row in self.value]
+        df = pandas.DataFrame(data_dicts)
+
+        if include_path_as_column:
+            df["path"] = str(self.path)
+
+        return df

--- a/src/fukinotou/image_loader.py
+++ b/src/fukinotou/image_loader.py
@@ -65,11 +65,11 @@ class ImageFilesLoadResult(BaseModel):
     Model representing the result of loading multiple image files.
 
     Attributes:
-        directory_path: Path to the source directory
+        path: Path to the source directory
         value: List of results for each loaded file
     """
 
-    directory_path: Path
+    path: Path
     value: List[ImageFileLoadResult]
 
 
@@ -105,6 +105,6 @@ class ImageFilesLoader:
             ImageFileLoader().load(image_file) for image_file in image_file_paths
         ]
         return ImageFilesLoadResult(
-            directory_path=p,
+            path=p,
             value=results,
         )

--- a/src/fukinotou/jsonl_loader.py
+++ b/src/fukinotou/jsonl_loader.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 from typing import List, Type, TypeVar, Generic
-import polars
-import pandas
 import json
 from pydantic import BaseModel, ValidationError
 
+from fukinotou.dataframe_exportable import DataframeExportable
 from fukinotou.load_error import LoadingError
 
 T = TypeVar("T", bound=BaseModel)
@@ -22,7 +21,7 @@ class JsonlRowLoadResult(BaseModel, Generic[T]):
     row: T
 
 
-class JsonlLoadResult(BaseModel, Generic[T]):
+class JsonlLoadResult(BaseModel, Generic[T], DataframeExportable):
     """Model representing the result of loading an entire JSONL file.
 
     Attributes:
@@ -32,54 +31,6 @@ class JsonlLoadResult(BaseModel, Generic[T]):
 
     path: Path
     value: List[JsonlRowLoadResult[T]]
-
-    def to_polars(self, include_path_as_column: bool = False) -> polars.DataFrame:
-        """Convert the result to a Polars DataFrame.
-
-        This method converts all model instances in the result to a Polars DataFrame.
-        Each row in the DataFrame represents one model instance.
-
-        Args:
-            include_path_as_column: If True, adds a 'path' column with the file path
-                                    for each row. Default is False.
-
-        Returns:
-            Polars DataFrame containing the model data
-        """
-        if not self.value:
-            return polars.DataFrame()
-
-        data_dicts = [row.row.model_dump() for row in self.value]
-        df = polars.DataFrame(data_dicts)
-
-        if include_path_as_column:
-            df = df.with_columns(polars.lit(str(self.path)).alias("path"))
-
-        return df
-
-    def to_pandas(self, include_path_as_column: bool = False) -> pandas.DataFrame:
-        """Convert the result to a Pandas DataFrame.
-
-        This method converts all model instances in the result to a Pandas DataFrame.
-        Each row in the DataFrame represents one model instance.
-
-        Args:
-            include_path_as_column: If True, adds a 'path' column with the file path
-                                    for each row. Default is False.
-
-        Returns:
-            Pandas DataFrame containing the model data
-        """
-        if not self.value:
-            return pandas.DataFrame()
-
-        data_dicts = [row.row.model_dump() for row in self.value]
-        df = pandas.DataFrame(data_dicts)
-
-        if include_path_as_column:
-            df["path"] = str(self.path)
-
-        return df
 
 
 class JsonlLoader(Generic[T]):

--- a/src/fukinotou/jsonl_loader.py
+++ b/src/fukinotou/jsonl_loader.py
@@ -14,11 +14,11 @@ class JsonlRowLoadResult(BaseModel, Generic[T]):
 
     Attributes:
         path: Path to the JSONL file from which this row was loaded
-        row: The parsed and validated row data as a model instance
+        value: The parsed and validated row data as a model instance
     """
 
     path: Path
-    row: T
+    value: T
 
 
 class JsonlLoadResult(BaseModel, Generic[T], DataframeExportable):
@@ -99,7 +99,7 @@ class JsonlLoader(Generic[T]):
                         error_message=f"Error validating row {lineno} of {p}: {e}",
                     )
 
-                jsonl_rows.append(JsonlRowLoadResult(path=p, row=parsed))
+                jsonl_rows.append(JsonlRowLoadResult(path=p, value=parsed))
         except FileNotFoundError as e:
             raise LoadingError(
                 original_exception=e, error_message=f"Error reading file {p}: {e}"


### PR DESCRIPTION
This pull request refactors several data loaders (`csv_loader`, `json_loader`, `jsonl_loader`, and `parquet_loader`) to enhance code reuse and consistency by introducing a new `DataframeExportable` base class. Additionally, it standardizes attribute names across loaders and removes redundant methods for converting data to Pandas and Polars DataFrames.

### Code Reusability and Simplification:
* Introduced a new `DataframeExportable` base class in `src/fukinotou/dataframe_exportable.py`, which provides shared implementations of `to_pandas` and `to_polars` methods for converting data to Pandas and Polars DataFrames. This class is now inherited by loaders such as `CsvLoadResult`, `JsonsLoadResult`, `JsonlLoadResult`, and `ParquetLoadResult`. [[1]](diffhunk://#diff-b04418ab9108f723a0ce3365991f0282ac742d37263c558d364f15ecd1b9eccfR1-R60) [[2]](diffhunk://#diff-1e8d880e48788d4a04927af96844f05889aea80c4411b97bc291adb970d2a393L25-R24) [[3]](diffhunk://#diff-e786a5404f2f7e0dcd5b9f90bff28f92e92b325a0f4ea7742c90ba8164623b73L27-R26) [[4]](diffhunk://#diff-4699990782535f0a48da4871cc3b5cb02d5843d79cece44aa5464fb8be6271cdL37-L84) [[5]](diffhunk://#diff-12cde9a8b07538f194b429ec9d6bd701900b914b10a1a3172e6b3a90b21ebf9aL86-L151)

### Standardization of Attribute Names:
* Renamed the `row` attribute to `value` in `CsvRowLoadResult` for consistency across loaders. [[1]](diffhunk://#diff-4699990782535f0a48da4871cc3b5cb02d5843d79cece44aa5464fb8be6271cdL19-R25) [[2]](diffhunk://#diff-4699990782535f0a48da4871cc3b5cb02d5843d79cece44aa5464fb8be6271cdL160-R111)
* Standardized the `directory_path` attribute to `path` in `JsonsLoadResult`, `ImageFilesLoadResult`, and related methods for consistency. [[1]](diffhunk://#diff-12cde9a8b07538f194b429ec9d6bd701900b914b10a1a3172e6b3a90b21ebf9aL86-L151) [[2]](diffhunk://#diff-bc411e672c17119758410338d04e0930b0e546a77d3f30a8e399b7d786d4013bL68-R72) [[3]](diffhunk://#diff-bc411e672c17119758410338d04e0930b0e546a77d3f30a8e399b7d786d4013bL108-R108)

### Removal of Redundant Code:
* Removed the `to_pandas` and `to_polars` methods from `CsvLoadResult`, `JsonsLoadResult`, `JsonlLoadResult`, and `ParquetLoadResult` classes, as these methods are now implemented in the `DataframeExportable` base class. [[1]](diffhunk://#diff-4699990782535f0a48da4871cc3b5cb02d5843d79cece44aa5464fb8be6271cdL37-L84) [[2]](diffhunk://#diff-12cde9a8b07538f194b429ec9d6bd701900b914b10a1a3172e6b3a90b21ebf9aL86-L151) [[3]](diffhunk://#diff-1e8d880e48788d4a04927af96844f05889aea80c4411b97bc291adb970d2a393L36-L83) [[4]](diffhunk://#diff-e786a5404f2f7e0dcd5b9f90bff28f92e92b325a0f4ea7742c90ba8164623b73L39-L87)

### Dependency Cleanup:
* Removed unused imports of `pandas` and `polars` from files where the `DataframeExportable` class is now handling DataFrame conversions. [[1]](diffhunk://#diff-4699990782535f0a48da4871cc3b5cb02d5843d79cece44aa5464fb8be6271cdL5-R8) [[2]](diffhunk://#diff-12cde9a8b07538f194b429ec9d6bd701900b914b10a1a3172e6b3a90b21ebf9aL5-R8) [[3]](diffhunk://#diff-1e8d880e48788d4a04927af96844f05889aea80c4411b97bc291adb970d2a393L3-R6) [[4]](diffhunk://#diff-e786a5404f2f7e0dcd5b9f90bff28f92e92b325a0f4ea7742c90ba8164623b73L4-R7)

These changes improve maintainability, reduce code duplication, and ensure consistent naming conventions across the project.