### PR TITLE
fix: Create Release を冪等化しリリース bump skill を追加 (#37)

### DIFF
--- a/.claude/skills/bump__version/SKILL.md
+++ b/.claude/skills/bump__version/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: bump__version
+description: >-
+  fukinotou のリリースバージョンを上げたいときに起動する。pyproject.toml の
+  version を semver (major/minor/patch) で bump し、uv.lock を同期する。
+  リポジトリ慣習に従い release/vX.Y.Z ブランチを切って commit・push し、
+  main への PR を作成する。PR が main にマージされると Create Release
+  ワークフローが起動して新しい GitHub Release が作られる。
+tools: Bash, Read, Edit
+model: inherit
+---
+
+あなたはリリースバージョン管理の専門家である。このスキルは fukinotou の
+**バージョン bump** を所有する。現行バージョンから次バージョンを算出し、
+`pyproject.toml` と `uv.lock` を更新し、リポジトリ慣習に沿ったブランチと PR で
+リリース準備を整える。
+
+## 前提: リリースの仕組み
+
+`.github/workflows/release.yml` は **main への push** で起動し、`pyproject.toml`
+の version から `vX.Y.Z` タグを算出して `gh release create` を実行する。既存タグ
+と同名だと失敗するため、リリースには **version の更新が必須** である
+(関連: 既存タグ重複で失敗する Issue #37)。
+
+したがってリリースは次の流れで行う。
+
+1. `pyproject.toml` の version を上げる (このスキルの責務)
+2. `release/vX.Y.Z` ブランチで commit・push し、main への PR を作る
+3. PR が main にマージされる → `Create Release` が新バージョンのタグでリリースを作成
+
+過去のリリースも `release/vX.Y.Z` ブランチを main へ PR マージする形式で行われている
+(`Merge pull request #20 from shunsock/release/v0.1.0`)。この慣習を踏襲する。
+
+## Trigger Condition
+
+以下をユーザーが要求したとき起動する。
+
+- 「バージョンを上げて」「リリースして」「bump して」といった依頼
+- パッチ / マイナー / メジャーリリースの準備依頼
+
+## 引数の解釈
+
+ユーザーの指示から bump 種別を決める。判別できないときのみ確認する。
+
+| 指示の例 | 種別 | 0.1.0 → |
+|---|---|---|
+| 「パッチ」「バグfix」「patch」 | patch | 0.1.1 |
+| 「マイナー」「機能追加」「minor」 | minor | 0.2.0 |
+| 「メジャー」「破壊的変更」「major」 | major | 1.0.0 |
+| 「0.3.0 にして」等の明示 | explicit | 0.3.0 |
+
+semver の規則で算出する: patch は Z+1、minor は Y+1 かつ Z=0、major は X+1 かつ
+Y=Z=0。明示指定なら妥当な semver (`X.Y.Z`) であることを検証してから使う。
+
+## Execution Steps
+
+### Phase 1: 現行バージョンを読み取り、次バージョンを算出する
+
+`pyproject.toml` の `[project]` にある `version = "X.Y.Z"` を Read で取得する。
+上表の規則で次バージョン `NEW_VERSION` とタグ `vNEW_VERSION` を決める。
+
+算出した新バージョンのタグが既に存在しないことを確認する。存在する場合は中止し、
+ユーザーに報告する (重複は release ワークフローを失敗させるため)。
+
+```bash
+git tag -l | grep -qx "vNEW_VERSION" && echo "tag exists: abort" || echo "ok"
+gh release view "vNEW_VERSION" >/dev/null 2>&1 && echo "release exists: abort" || echo "ok"
+```
+
+### Phase 2: version を更新し uv.lock を同期する
+
+`pyproject.toml` の version 行だけを Edit で書き換える。`[project]` の version を
+対象にし、依存パッケージの version 指定を誤って触らないこと。
+
+```diff
+ [project]
+ name = "fukinotou"
+-version = "0.1.0"
++version = "0.1.1"
+```
+
+続いて `uv.lock` 内の fukinotou 自身の version エントリ (`name = "fukinotou"` の
+直下) を pyproject と一致させる。手編集ではなく `uv lock` で再生成する。
+
+```bash
+uv lock
+```
+
+`git diff uv.lock` で fukinotou の version のみが変わったことを確認する。想定外の
+依存差分が出た場合は立ち止まってユーザーに報告する。
+
+### Phase 3: 品質ゲートを通す
+
+commit 前に既存のテスト・型・lint を通す (CLAUDE.md の品質確認フローに従う)。
+
+```bash
+task test
+task typecheck
+task lint
+```
+
+いずれか失敗したら commit せず、原因をユーザーに報告する。bump は成果物の内容を
+変えないため通常は通るが、破損状態でのリリースを防ぐガードとして必ず実行する。
+
+### Phase 4: ブランチ・commit・push・PR
+
+`release/vX.Y.Z` ブランチを作成し、変更を commit・push して main への PR を作る。
+CLAUDE.md により commit / push / PR 作成はユーザー確認不要で自動実行してよい。
+ただし `git push --force` は禁止。
+
+```bash
+git switch -c "release/vNEW_VERSION"
+git add pyproject.toml uv.lock
+git commit -m "release: vNEW_VERSION"
+git push -u origin "release/vNEW_VERSION"
+gh pr create \
+  --base main \
+  --title "release: vNEW_VERSION" \
+  --body "$(printf 'bump version to vNEW_VERSION\n\nmain マージで Create Release ワークフローが起動し vNEW_VERSION のリリースが作成される。')"
+```
+
+### Phase 5: リリースの起動を見届ける
+
+PR がマージされると main への push で `Create Release` が起動する。マージ後に
+CI 監視 (monitor__ci_status) の対象になる。PR 作成直後の時点では、ユーザーに PR の
+URL と「main マージでリリースが自動作成される」旨を伝えて完了とする。
+
+## 完了報告に含める内容
+
+- 旧バージョン → 新バージョン
+- 作成したブランチ名と PR の URL
+- 品質ゲート (test / typecheck / lint) の結果
+- 「PR を main にマージすると vNEW_VERSION のリリースが自動作成される」旨
+
+## Prohibited Actions
+
+- 既に存在するタグ / リリースと同じバージョンへ bump する (release ワークフローが失敗する)
+- semver 規則に反するバージョン (`v1`, `0.1`, `1.0.0.0` 等) を設定する
+- `uv.lock` を手編集で書き換える (必ず `uv lock` で再生成する)
+- `pyproject.toml` の依存パッケージの version 指定を誤って変更する
+- 品質ゲートが失敗した状態で commit・push する
+- `git push --force` / `git push -f` を使う
+- main へ直接 push する (必ず release/vX.Y.Z ブランチと PR を経由する)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,24 @@ jobs:
       - name: Build
         run: uv build
 
+      # version が変わらない main への push でも同名タグで作成を試みると失敗するため、
+      # 既存リリースの有無を確認してリリース作成を冪等にする (Issue #37)。
+      - name: check existing release
+        id: check_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists. Skipping."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # release 作成は外部 action でなく runner 同梱の gh で行う (zizmor の指摘。
       # 外部依存が減り supply-chain 面でも安全)。
       - name: create release
+        if: steps.check_release.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## 概要

`main` への push のたびに失敗し続けていた `Create Release` ワークフローを冪等化し、あわせてリリース時の version bump を自動化する `bump__version` skill を追加する。

Closes #37

## 背景

`Validate` や `lint__*` は緑なのに、`Create Release` ジョブだけが恒常的に赤くなっていた。dependabot の依存更新 push が続くたびに失敗が積み上がり、CI のシグナルとしてノイズになっていた。ログを追うと `create release` ステップが次で落ちていた。

```
a release with the same tag name already exists: v0.1.0
##[error]Process completed with exit code 1.
```

## 課題

`release.yml` は `main` push 全てで起動し、毎回 `pyproject.toml` の version (`0.1.0`) から `v0.1.0` タグでリリースを作ろうとする。しかし `v0.1.0` は 2025-04-29 に作成済みで、以降 version を据え置いた push は全て同名タグ重複で失敗していた。version を上げない限りリリース作成は必ずコケる構造で、通常の push が CI 赤を生む状態だった。

## 目標

### 必須項目

- version を変えない `main` push で `Create Release` が失敗しない (スキップして成功)
- version を上げた push では従来どおり新リリースが 1 度だけ作成される
- 同一 version で複数回起動してもリリースが重複せず失敗もしない (冪等性)

### 範囲外

- 既存 version 時にビルド自体をスキップするビルドコスト削減 (別途対応)
- トリガーを tag push 起点にするリリースフロー全体の再設計 (別 Issue で検討)

## 採用手法

`create release` の前に `gh release view` で対象タグのリリース有無を確認するガードステップを追加し、存在する場合は `if` 条件で作成ステップをスキップする。既存の「main push で自動リリース」思想を維持したまま、最小変更で冪等化できる。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 既存リリース確認ガードを追加 (採用) | 最小変更。トリガー維持。version 更新時のみ作成 | 毎 push でビルドまでは走る |
| B: トリガーを `push: tags: ['v*']` に変更 | タグ push 時のみ起動し明快 | タグ運用フローへの前提変更が必要。既存思想と乖離 |
| C: `paths: [pyproject.toml]` フィルタ | 設定が単純 | dependabot でも pyproject は変わり根本解決にならない |

### 採用理由

現行のリリース起動思想 (main push 自動リリース) を壊さず、失敗している 1 ステップだけを冪等化するのが影響範囲最小だから。B・C はフローや前提の変更を伴い、今回の「失敗を止める」目的に対して過剰かつ副作用が大きい。

あわせて追加した `bump__version` skill は、この修正と補完関係にある。冪等化は「version を変えない通常 push を失敗させない」ための守りで、bump skill は「version を上げて実際にリリースを起こす」ための攻めの導線である。skill はリポジトリ慣習 (`release/vX.Y.Z` ブランチ → main への PR マージで `Create Release` 起動) を踏襲する。

```mermaid
flowchart LR
  Bump[bump__version skill] -->|version 更新 PR| Merge[main マージ]
  Merge -->|push| Release[Create Release]
  Release -->|新タグのみ作成/既存はスキップ| Idempotent[冪等ガード #37]
```

## 変更箇所

- `.github/workflows/release.yml`: `check existing release` ステップを追加し、`create release` に `if: steps.check_release.outputs.exists == 'false'` を付与して冪等化
- `.claude/skills/bump__version/SKILL.md`: pyproject.toml の version を semver で bump し uv.lock を同期、`release/vX.Y.Z` ブランチと PR を作る skill を追加 (ドキュメントのみ)

## 妥協と制限

- **毎 push でビルドは走る**: ガードは `create release` のスキップのみで、`Build` までは既存 version でも実行される。ビルドコスト削減は範囲外とした。
- **効果確認はマージ後**: `Create Release` は PR (pull_request) では起動せず main push で走るため、冪等化の実挙動確認はマージ後の main push を待つ必要がある。

## 検証方法

- `.github/workflows/release.yml` を actionlint で検証 (exit 0)
- yamllint (max 120 baseline) を通過
- 追加した `run:` ブロックは if/else 1 分岐で認知的複雑度は十分低い
- マージ後、version 据え置き push で `Create Release` が緑になること、version 更新 push で新リリースが作られることを確認予定

## 確認事項

- ⚠️ `Create Release` は `pull_request` では起動しないため、この PR の CI では冪等化の実挙動は検証できない。マージ後の main push で確認する前提でよいか。
- ⚠️ bump skill はプロジェクトスコープ (`.claude/skills/`) に配置した。global (dotfiles 経由) ではなく本リポジトリに含める方針で合意済み。

## 参考文献

- [Issue #37: Create Release ワークフローが既存タグ v0.1.0 と重複し main push のたびに失敗する](https://github.com/shunsock/fukinotou/issues/37)
